### PR TITLE
Duplicate error state

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -65,7 +65,7 @@ export function App() {
     if (thing) {
       const newThingsArray = [...thingsArray];
       delete newThingsArray[index];
-      const updatedThingsArray = newThingsArray.filter(things => things)
+      const updatedThingsArray = newThingsArray.filter(things => things);
       setThingsArray(updatedThingsArray)
     }
   };

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -51,6 +51,8 @@ export function App() {
         setThingsArray([...thingsArray, trimmedInput]);
         setInputValue("");
       }
+      if (thingsArray.includes(trimmedInput)) {
+      }
     }
   };
 

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -26,9 +26,11 @@ const boxProps = {
 
 //Root App Component
 export function App() {
+
   const [isCompareMode, setCompareMode] = useState(false);
   const [thingsArray, setThingsArray] = useState([]);
   const [inputValue, setInputValue] = useState("");
+  const [isDuplicate, setDuplicateError] = useState(false);
 
   const onChange = event => {
     setInputValue(event.target.value);
@@ -50,8 +52,10 @@ export function App() {
       if (!thingsArray.includes(trimmedInput)) {
         setThingsArray([...thingsArray, trimmedInput]);
         setInputValue("");
+        setDuplicateError(false)
       }
       if (thingsArray.includes(trimmedInput)) {
+        setDuplicateError(true)
       }
     }
   };
@@ -84,6 +88,7 @@ export function App() {
             onChange={onChange}
             onKeyDown={onKeyDown}
             onModeChangeClick={onModeChangeClick}
+            isDuplicate={isDuplicate}
         /> 
         ) 
 

--- a/src/components/inputMode.jsx
+++ b/src/components/inputMode.jsx
@@ -1,13 +1,15 @@
 //library
 import React from "react";
-import { Paragraph, TextInput, Box, Button, FormField } from "grommet";
+import { Paragraph, TextInput, Box, Button } from "grommet";
 
 //custom components
 import { Thing } from "./thing";
+import { isDuplicate } from "./app"
 
 const textInputBoxProps = {
   align: "center",
   width: "medium",
+  direction: "row",
 };
 
 const listBoxProps = {
@@ -21,6 +23,12 @@ const listBoxProps = {
   }
 };
 
+const errorTextProps = {
+  color: "status-error",
+  size: "small",
+  margin: {bottom:"none"}
+}
+
 export function InputMode(props) {
   const {
     inputValue,
@@ -30,10 +38,10 @@ export function InputMode(props) {
     onChange,
     onKeyDown,
     onModeChangeClick,
+    isDuplicate
   } = props;
 
   const lessThan3Things = thingsArray.length < 3;
-  const isDuplicate = true;
 
   return (
     <>
@@ -41,7 +49,6 @@ export function InputMode(props) {
         {"Let's prioritize! Start by adding a handful of things below."}
       </Paragraph>
       <Box {...textInputBoxProps}>
-        <Box {...textInputBoxProps} direction="row">
           <TextInput
             placeholder="Add a thing..."
             size="medium"
@@ -50,11 +57,9 @@ export function InputMode(props) {
             onKeyDown={onKeyDown}
           />
           <Button label="+Add" onClick={addThing} margin="small" />
-        </Box>
-        <Paragraph color="status-error">
-        {isDuplicate && `Oops! You can't add the same thing twice.`}
-        </Paragraph>
       </Box>
+      {isDuplicate && 
+          <Paragraph {...errorTextProps}>Oops! You can't add the same thing twice.</Paragraph>}
       <Box {...listBoxProps}>
         <Paragraph color="dark-5">
           {lessThan3Things &&

--- a/src/components/inputMode.jsx
+++ b/src/components/inputMode.jsx
@@ -1,6 +1,6 @@
 //library
 import React from "react";
-import { Paragraph, TextInput, Box, Button } from "grommet";
+import { Paragraph, TextInput, Box, Button, FormField } from "grommet";
 
 //custom components
 import { Thing } from "./thing";
@@ -8,7 +8,6 @@ import { Thing } from "./thing";
 const textInputBoxProps = {
   align: "center",
   width: "medium",
-  direction: "row"
 };
 
 const listBoxProps = {
@@ -34,6 +33,7 @@ export function InputMode(props) {
   } = props;
 
   const lessThan3Things = thingsArray.length < 3;
+  const isDuplicate = true;
 
   return (
     <>
@@ -41,14 +41,19 @@ export function InputMode(props) {
         {"Let's prioritize! Start by adding a handful of things below."}
       </Paragraph>
       <Box {...textInputBoxProps}>
-        <TextInput
-          placeholder="Add a thing..."
-          size="medium"
-          value={inputValue}
-          onChange={onChange}
-          onKeyDown={onKeyDown}
-        />
-        <Button label="+Add" onClick={addThing} margin="small" />
+        <Box {...textInputBoxProps} direction="row">
+          <TextInput
+            placeholder="Add a thing..."
+            size="medium"
+            value={inputValue}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+          />
+          <Button label="+Add" onClick={addThing} margin="small" />
+        </Box>
+        <Paragraph color="status-error">
+        {isDuplicate && `Oops! You can't add the same thing twice.`}
+        </Paragraph>
       </Box>
       <Box {...listBoxProps}>
         <Paragraph color="dark-5">


### PR DESCRIPTION
Added an error message below the text input field when users attempt to add a duplicate thing.

**Testing Steps:**
1. Add a thing called "duplicate"
2. Add a second thing called "duplicate"
3. See that the thing is not added and a red error message shows below the field
4. Add a thing that is NOT a duplicate
5. See that the new thing is added and the error message goes away

For the future...we may want to think about whether or not this error message should go away if folks delete all the things in the list while the error still exists. I don't think that's a bug. More like a future enhancement.